### PR TITLE
Binary search fix

### DIFF
--- a/__tests__/wordnet_test.js
+++ b/__tests__/wordnet_test.js
@@ -111,6 +111,14 @@ describe('Wordnet methods', () => {
         });
     });
 
+    it('should succeed for ulteriority', () => {
+      return wordnet.lookup('ulteriority')
+        .then((result) => {
+          expect(result).toBeInstanceOf(Array);
+          expect(result).toHaveLength(1);
+        });
+    });
+
   });
 
 

--- a/lib/index-file.js
+++ b/lib/index-file.js
@@ -54,7 +54,7 @@ function _findAt(self, fd, size, pos, previousPos, adjustment, searchKey, previo
   
         if (key === searchKey) {
           return Promise.resolve({status: 'hit', key, 'line': line, tokens});
-        } else if ((adjustment === 1) || (key === previousKey)) {
+        } else if (adjustment === 1) {
           return Promise.resolve({status: 'miss'});
         } else {
           adjustment = Math.ceil(adjustment * 0.5);


### PR DESCRIPTION
I noticed that some words (such as "ulteriority") couldn't be looked up, due to a bug in `_findAt`.

This problem can occur when a line is longer than `adjustment` and therefore multiple recursions are necessary to traverse the line.